### PR TITLE
Update install requirements setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     attrs
     pyelftools
     commoncode
-    typecode
+    typecode[full]
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
We use typecode and need the [full] extra as a dependency

Reference: https://github.com/nexB/elf-inspector/issues/2
Reported-by: Anthony Harrison <anthony.p.harrison@gmail.com>